### PR TITLE
account for invalid merge value

### DIFF
--- a/mfunc.go
+++ b/mfunc.go
@@ -162,6 +162,11 @@ func mergeStruct(t, s reflect.Value, o *Options) (reflect.Value, error) {
 				newT.Type().Name(), newT.Type().Field(i).Name, err)
 		}
 
+		if !merged.IsValid() {
+			return reflect.Value{}, fmt.Errorf("merged value is invalid for field %s: %v <> %v",
+				newT.Type().Field(i).Name, valT.Field(i), valS.Field(i))
+		}
+
 		if fieldT.Kind() != reflect.Interface && fieldT.Type() != merged.Type() {
 			return reflect.Value{}, fmt.Errorf("types dont match %v <> %v", fieldT.Type(), merged.Type())
 		}

--- a/mfunc_test.go
+++ b/mfunc_test.go
@@ -861,6 +861,44 @@ var _ = Describe("mergeStruct", func() {
 		})
 	})
 
+	Context("invalid merge value", func() {
+		type Baz struct {
+			Bar *Foo
+		}
+
+		var targetBaz, sourceBaz Baz
+		var targetBazVal, sourceBazVal reflect.Value
+
+		Context("invalid returned from merge", func() {
+			BeforeEach(func() {
+				targetBaz = Baz{
+					Bar: &Foo{},
+				}
+
+				sourceBaz = Baz{
+					Bar: &Foo{},
+				}
+			})
+
+			JustBeforeEach(func() {
+				targetBazVal = reflect.ValueOf(targetBaz)
+				sourceBazVal = reflect.ValueOf(sourceBaz)
+			})
+
+			It("merges them", func() {
+				opt := NewOptions()
+				opt.MergeFuncs.SetTypeMergeFunc(reflect.TypeOf(&Foo{}),
+					func(t, s reflect.Value, o *Options) (reflect.Value, error) {
+						return reflect.ValueOf(nil), nil
+					},
+				)
+				_, err := mergeStruct(targetBazVal, sourceBazVal, opt)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("merged value is invalid"))
+			})
+		})
+	})
+
 	// These are tested through the merge() func because that is what protects against panics
 	Context("invalid entries", func() {
 		var opt *Options


### PR DESCRIPTION
It is possible for `merge()` to return a zero value. Error to prevent panic. 
@manute 