### PR TITLE
accept values

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	"github.com/InVisionApp/conjungo"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func init() {

--- a/merge.go
+++ b/merge.go
@@ -39,6 +39,13 @@ func Merge(target, source interface{}, opt *Options) error {
 	vT := reflect.ValueOf(target)
 	vS := reflect.ValueOf(source)
 
+	if target != nil && vT.Type() == reflect.TypeOf(reflect.Value{}) {
+		vT = vT.Interface().(reflect.Value)
+	}
+	if source != nil && vS.Type() == reflect.TypeOf(reflect.Value{}) {
+		vS = vS.Interface().(reflect.Value)
+	}
+
 	if vT.Kind() != reflect.Ptr {
 		return errors.New("target must be a pointer")
 	}

--- a/merge.go
+++ b/merge.go
@@ -34,15 +34,17 @@ func NewOptions() *Options {
 	}
 }
 
+var valType = reflect.TypeOf(reflect.Value{})
+
 // public wrapper
 func Merge(target, source interface{}, opt *Options) error {
 	vT := reflect.ValueOf(target)
 	vS := reflect.ValueOf(source)
 
-	if target != nil && vT.Type() == reflect.TypeOf(reflect.Value{}) {
+	if target != nil && vT.Type() == valType {
 		vT = vT.Interface().(reflect.Value)
 	}
-	if source != nil && vS.Type() == reflect.TypeOf(reflect.Value{}) {
+	if source != nil && vS.Type() == valType {
 		vS = vS.Interface().(reflect.Value)
 	}
 

--- a/merge.go
+++ b/merge.go
@@ -88,14 +88,12 @@ func isSettable(t, s reflect.Value) bool {
 
 func merge(valT, valS reflect.Value, opt *Options) (reflect.Value, error) {
 	// if source is nil, skip
-	if !valS.IsValid() ||
-		valS.Kind() == reflect.Ptr && valS.IsNil() {
+	if isEmpty(valS) {
 		return valT, nil
 	}
 
 	// if target is nil write to it
-	if !valT.IsValid() ||
-		valT.Kind() == reflect.Ptr && valT.IsNil() {
+	if isEmpty(valT) {
 		return valS, nil
 	}
 
@@ -118,4 +116,20 @@ func merge(valT, valS reflect.Value, opt *Options) (reflect.Value, error) {
 	}
 
 	return val, nil
+}
+
+func isEmpty(val reflect.Value) bool {
+	// is zero value
+	if !val.IsValid() {
+		return true
+	}
+
+	switch val.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Chan, reflect.Func, reflect.Interface, reflect.Slice:
+		if val.IsNil() {
+			return true
+		}
+	}
+
+	return false
 }

--- a/merge.go
+++ b/merge.go
@@ -64,8 +64,7 @@ func Merge(target, source interface{}, opt *Options) error {
 	//make a copy here so if there is an error mid way, the target stays in tact
 	cp := vT.Elem()
 
-	//TODO reflect.Indirect(vS)?
-	merged, err := merge(cp, vS, opt)
+	merged, err := merge(cp, reflect.Indirect(vS), opt)
 	if err != nil {
 		return err
 	}

--- a/merge_suite_test.go
+++ b/merge_suite_test.go
@@ -3,7 +3,7 @@ package conjungo
 import (
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/merge_test.go
+++ b/merge_test.go
@@ -625,6 +625,54 @@ var _ = Describe("MergeMapStrIFace", func() {
 	})
 })
 
+var _ = Describe("isEmpty", func() {
+	It("not empty", func() {
+		res := isEmpty(reflect.ValueOf("not empty"))
+		Expect(res).ToNot(BeTrue())
+	})
+
+	It("not valid", func() {
+		res := isEmpty(reflect.ValueOf(nil))
+		Expect(res).To(BeTrue())
+	})
+
+	It("empty map", func() {
+		var v map[string]interface{}
+		res := isEmpty(reflect.ValueOf(v))
+		Expect(res).To(BeTrue())
+	})
+
+	It("empty slice", func() {
+		var v []interface{}
+		res := isEmpty(reflect.ValueOf(v))
+		Expect(res).To(BeTrue())
+	})
+
+	It("nil pointer", func() {
+		var v *int = nil
+		res := isEmpty(reflect.ValueOf(v))
+		Expect(res).To(BeTrue())
+	})
+
+	It("nil chan", func() {
+		var v chan int
+		res := isEmpty(reflect.ValueOf(v))
+		Expect(res).To(BeTrue())
+	})
+
+	It("nil func", func() {
+		var v func()
+		res := isEmpty(reflect.ValueOf(v))
+		Expect(res).To(BeTrue())
+	})
+
+	It("nil interface", func() {
+		var v interface{}
+		res := isEmpty(reflect.ValueOf(v))
+		Expect(res).To(BeTrue())
+	})
+})
+
 func erroringMergeFunc(t, s reflect.Value, o *Options) (reflect.Value, error) {
 	return reflect.Value{}, errors.New("returns error")
 }

--- a/merge_test.go
+++ b/merge_test.go
@@ -380,6 +380,64 @@ var _ = Describe("Merge", func() {
 				Expect(target).To(ContainElement(1))
 			})
 		})
+
+		Context("merge struct", func() {
+			type Thing struct {
+				Foo string
+			}
+
+			It("merges correctly", func() {
+				target := Thing{Foo: "bar"}
+				source := Thing{Foo: "baz"}
+
+				err := Merge(&target, source, NewOptions())
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(target.Foo).To(Equal("baz"))
+			})
+
+			It("target struct and source value merges correctly", func() {
+				target := Thing{Foo: "bar"}
+				source := reflect.ValueOf(Thing{Foo: "baz"})
+
+				err := Merge(&target, source, NewOptions())
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(target.Foo).To(Equal("baz"))
+			})
+
+			It("target value and source struct merges correctly", func() {
+				target := Thing{Foo: "bar"}
+				source := Thing{Foo: "baz"}
+
+				tVal := reflect.ValueOf(&target)
+				err := Merge(tVal, source, NewOptions())
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(target.Foo).To(Equal("baz"))
+			})
+
+			It("both values merges correctly", func() {
+				target := Thing{Foo: "bar"}
+				source := reflect.ValueOf(Thing{Foo: "baz"})
+
+				err := Merge(reflect.ValueOf(&target), source, NewOptions())
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(target.Foo).To(Equal("baz"))
+			})
+
+			It("pointer to target value errors", func() {
+				target := Thing{Foo: "bar"}
+				source := reflect.ValueOf(Thing{Foo: "baz"})
+
+				tVal := reflect.ValueOf(&target)
+				err := Merge(tVal, source, NewOptions())
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(target.Foo).To(Equal("baz"))
+			})
+		})
 	})
 
 	Context("failure modes", func() {

--- a/mfunc.go
+++ b/mfunc.go
@@ -1,7 +1,6 @@
 package conjungo
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -93,11 +92,7 @@ func mergeMap(t, s reflect.Value, o *Options) (v reflect.Value, err error) {
 
 	defer func() {
 		if r := recover(); r != nil {
-			vr := reflect.ValueOf(r)
-			if vr.Kind() == reflect.String {
-				//TODO: make this easier to debug
-				err = errors.New("failed to merge map: " + r.(string))
-			}
+			err = fmt.Errorf("failed to merge map: %v", r)
 		}
 	}()
 
@@ -142,7 +137,7 @@ func mergeStruct(t, s reflect.Value, o *Options) (reflect.Value, error) {
 
 	for i := 0; i < valS.NumField(); i++ {
 		fieldT := newT.Field(i)
-		logrus.Debug("merging struct field %s", fieldT)
+		logrus.Debugf("merging struct field %s", fieldT)
 
 		// field is addressable because it's created above. So this means it is unexported.
 		if !fieldT.CanSet() {

--- a/mfunc.go
+++ b/mfunc.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type funcSelector struct {

--- a/mfunc_test.go
+++ b/mfunc_test.go
@@ -381,12 +381,20 @@ var _ = Describe("mergeMap", func() {
 		// these are called via merge() because that is what does the nil checks
 		By("call via merge()")
 
-		Context("nil target", func() {
-			JustBeforeEach(func() {
-				targetMapVal = reflect.Value{}
-			})
-
+		Context("nil value target", func() {
 			It("equals source", func() {
+				targetMapVal = reflect.Value{}
+				merged, err := merge(targetMapVal, sourceMapVal, NewOptions())
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(merged.Interface()).To(Equal(sourceMap))
+			})
+		})
+
+		Context("nil map target", func() {
+			It("equals source", func() {
+				var m map[string]interface{}
+				targetMapVal = reflect.ValueOf(m)
 				merged, err := merge(targetMapVal, sourceMapVal, NewOptions())
 
 				Expect(err).ToNot(HaveOccurred())
@@ -592,6 +600,17 @@ var _ = Describe("mergeSlice", func() {
 					ContainElement(0),
 					ContainElement(3.6),
 				))
+			})
+		})
+
+		Context("nil slice target", func() {
+			It("equals source", func() {
+				var m []interface{}
+				targetSliceVal = reflect.ValueOf(m)
+				merged, err := merge(targetSliceVal, sourceSliceVal, NewOptions())
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(merged.Interface()).To(Equal(sourceSlice))
 			})
 		})
 


### PR DESCRIPTION
Overall robustness:
- Accept `reflect.Value` of the target and source to merge.
- Accept a pointer to source
- Accept uninitialized targets
- Robust panic recovery