### PR TITLE
Don't fail on different types if we aren't going to merge values anyway

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -147,7 +147,7 @@ func merge(valT, valS reflect.Value, opt *Options) (reflect.Value, error) {
 	}
 
 	// if types do not match, bail
-	if valT.Type() != valS.Type() {
+	if opt.Overwrite && valT.Type() != valS.Type() {
 		return reflect.Value{}, fmt.Errorf("Types do not match: %v, %v", valT.Type(), valS.Type())
 	}
 


### PR DESCRIPTION
If opts.Overwrite is false then we aren't going to merge anyway, so we don't need to complain that the two values are of different types.