### PR TITLE
Proposal: Add option IgnoreEmpty to always ignore source value when it is zero

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -14,6 +14,10 @@ type Options struct {
 	// Overwrite a target value with source value even if it already exists
 	Overwrite bool
 
+	// Don't overwrite target if source value is a zero value. Useful with the option Overwrite to
+	// overwrite a target value only when the source value is not empty.
+	IgnoreEmpty bool
+
 	// Unexported fields on a struct can not be set. When a struct contains an unexported
 	// field, the default behavior is to treat the entire struct as a single entity and
 	// replace according to Overwrite settings. If this is enabled, an error will be thrown instead.
@@ -38,8 +42,9 @@ type Options struct {
 // default merge function definitions are added.
 func NewOptions() *Options {
 	return &Options{
-		Overwrite:  true,
-		mergeFuncs: newFuncSelector(),
+		Overwrite:   true,
+		IgnoreEmpty: false,
+		mergeFuncs:  newFuncSelector(),
 	}
 }
 
@@ -162,7 +167,6 @@ func merge(valT, valS reflect.Value, opt *Options) (reflect.Value, error) {
 }
 
 func isEmpty(val reflect.Value) bool {
-	// is zero value
 	if !val.IsValid() {
 		return true
 	}

--- a/mfunc.go
+++ b/mfunc.go
@@ -78,6 +78,13 @@ func (f *funcSelector) getFunc(v reflect.Value) MergeFunc {
 // The most basic merge function to be used as default behavior.
 // In overwrite mode, it returns the source. Otherwise, it returns the target.
 func defaultMergeFunc(t, s reflect.Value, o *Options) (reflect.Value, error) {
+	// Explicitly using IsZero due to: val.IsZero() != !val.IsValid() as used by isEmpty()
+	// reflect.ValueOf("").IsZero() == true
+	// reflect.ValueOf("").IsValid() == true
+	if o.IgnoreEmpty && s.IsZero() {
+		return t, nil
+	}
+
 	if o.Overwrite {
 		return s, nil
 	}

--- a/mfunc_test.go
+++ b/mfunc_test.go
@@ -208,6 +208,48 @@ var _ = Describe("defaultMergeFunc", func() {
 		})
 	})
 
+	// Currently IgnoreEmpty without Override has the same effect as not setting it, preparing for additional options
+	// as I didn't want to tie it hard on Overwrite right now
+	Context("ignoreempty true, overwrite false and source not empty", func() {
+		It("returns source", func() {
+			opts.IgnoreEmpty = true
+			opts.Overwrite = false
+			merged, err := defaultMergeFunc(reflect.ValueOf("a"), reflect.ValueOf("b"), opts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged.Interface()).To(Equal("a"))
+		})
+	})
+
+	Context("ignoreempty true, overwrite false and source empty", func() {
+		It("returns source", func() {
+			opts.IgnoreEmpty = true
+			opts.Overwrite = false
+			merged, err := defaultMergeFunc(reflect.ValueOf("a"), reflect.ValueOf(""), opts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged.Interface()).To(Equal("a"))
+		})
+	})
+
+	Context("ignoreempty true, overwrite true and source not empty", func() {
+		It("returns source", func() {
+			opts.IgnoreEmpty = true
+			opts.Overwrite = true
+			merged, err := defaultMergeFunc(reflect.ValueOf("a"), reflect.ValueOf("b"), opts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged.Interface()).To(Equal("b"))
+		})
+	})
+
+	Context("ignoreempty true, overwrite true and source empty", func() {
+		It("returns source", func() {
+			opts.IgnoreEmpty = true
+			opts.Overwrite = true
+			merged, err := defaultMergeFunc(reflect.ValueOf("a"), reflect.ValueOf(""), opts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(merged.Interface()).To(Equal("a"))
+		})
+	})
+
 	Context("never errors", func() {
 		It("doesnt error", func() {
 			_, err := defaultMergeFunc(reflect.ValueOf(nil), reflect.ValueOf(nil), NewOptions())


### PR DESCRIPTION
Useful in combination with overwrite to only overwrite if the source is actually set. One can also make that possible by providing his own default func, but I thought this feature is worth to be available directly. Backwards compatible, does not change the current behaviour (see tests).

`reflect.Value{}.IsZero()` is available since golang 1.13 and the issue leading to this function and the reasoning behind it: https://github.com/golang/go/issues/7501

My gut proposed to change how isEmpty() works, but that broke a lot of things as it is used in a lot of places. So I kept adding this feature with as minimal changes as possible