### PR TITLE
Deep merge should continue on Ptr, fixes #23

### DIFF
--- a/mfunc_test.go
+++ b/mfunc_test.go
@@ -836,6 +836,7 @@ var _ = Describe("mergeStruct", func() {
 				Ptr    *string
 				Slice  *[]interface{}
 				Struct *Obj
+				Bytes  []byte
 			}
 
 			var targetBaz, sourceBaz Baz
@@ -848,11 +849,13 @@ var _ = Describe("mergeStruct", func() {
 					Ptr:    &t,
 					Slice:  &[]interface{}{"unchanged", 0},
 					Struct: &Obj{Name: "target"},
+					Bytes:  []byte("target"),
 				}
 				sourceBaz = Baz{
 					Ptr:    &s,
 					Slice:  &[]interface{}{"added", 1},
 					Struct: &Obj{Name: "source"},
+					Bytes:  []byte("source"),
 				}
 			})
 
@@ -878,6 +881,7 @@ var _ = Describe("mergeStruct", func() {
 					ContainElement(1),
 				))
 				Expect((*mergedStruct.Struct).Name).To(Equal(specialString("merge")))
+				Expect(mergedStruct.Bytes).To(Equal([]byte("targetsource")))
 			})
 
 			Context("source field is nil", func() {

--- a/mfunc_test.go
+++ b/mfunc_test.go
@@ -863,7 +863,7 @@ var _ = Describe("mergeStruct", func() {
 
 			It("handles them properly", func() {
 				opts := NewOptions()
-				opts.SetKindMergeFunc(reflect.TypeOf(specialString("")).Kind(),
+				opts.SetTypeMergeFunc(reflect.TypeOf(specialString("")),
 					func(t, s reflect.Value, o *Options) (reflect.Value, error) {
 						return reflect.ValueOf(specialString("merge")), nil
 					},


### PR DESCRIPTION
Test case for #23. As stated there, the deep merge stops once a target is a pointer. The pointer should be dereferenced and the deep merge should continue.